### PR TITLE
feat(plugin): add force status option for change Feishu notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths-ignore:
       - '**/README.md'
+      - '**/CHANGELOG.md'
+      - '**/doc/README.md'
     branches:
       # - 'main'
       - 'release-*'

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Please read [Contributor Guide](.github/CONTRIBUTING_DOC/CONTRIBUTING.md) for mo
 - [x] internationalization support: en-US, zh-CN more support see --help (v1.4.+)
 - [x] docker platform support
   - linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x (v1.4.+)
+- [x] `force-status` to change status for show card (v1.8+)
 - [ ] more perfect test case coverage
 - [ ] more perfect benchmark case
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -155,7 +155,7 @@ labels: # https://woodpecker-ci.org/docs/usage/workflow-syntax#labels
 steps:
   notification-feishu-failure:
     image: sinlov/woodpecker-feishu-group-robot:latest
-    pull: false
+    pull: true
     settings:
       # debug: true # plugin debug switch
       # force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -14,10 +14,11 @@ woodpecker-feishu-group-robot
 ## Features
 
 - [x] simple to set up and easy to use
-- [x] Supports ignoring build success notifications in the same steps and comparing notifications after the last build failure.
+- [x] Supports ignoring build success notifications in the same steps and comparing notifications after the last build
+  failure.
 - [x] internationalization support: en-US, zh-CN more support see --help (v1.4.+)
 - [x] docker platform support
-  - linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x (v1.4.+)
+    - linux/amd64 linux/386 linux/arm64/v8 linux/arm/v7 linux/ppc64le linux/s390x (v1.4.+)
 
 ## before use
 
@@ -35,6 +36,7 @@ woodpecker-feishu-group-robot
 | Name                           | Required | Default value     | Description                                                                                                       |
 |--------------------------------|----------|-------------------|-------------------------------------------------------------------------------------------------------------------|
 | `debug`                        | **no**   | *false*           | open debug log or open by env `PLUGIN_DEBUG`                                                                      |
+| `force-status`                 | **no**   | *""*              | force status (1.8+). If empty will use woodpecker ci pipeline status, only support `[success failure]`            |
 | `feishu-enable-debug-notice`   | **no**   | *false*           | when debug open, will not send message, must enable it to notice under debug open                                 |
 | `feishu-webhook`               | **yes**  | *none*            | feishu group robot webhook, end of feishu robot `https://open.feishu.cn/open-apis/bot/v2/hook/{web_hook}`         |
 | `feishu-secret`                | **yes**  | *none*            | feishu robot secret, just `signature verification`, empty will not open.                                          |
@@ -78,6 +80,8 @@ steps:
     pull: false
     settings:
       # debug: true # plugin debug switch
+      ## force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
+      # force-status: "failure"
       # feishu-enable-debug-notice: true when debug open, will not send message, must enable it to notice under debug open
       # feishu-ntp-target: "pool.ntp.org" # if not set will not sync ntp time
       feishu-webhook:
@@ -120,6 +124,8 @@ steps:
     image: woodpecker-feishu-group-robot
     settings:
       # debug: true # plugin debug switch
+      ## force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
+      # force-status: "failure"
       # feishu-enable-debug-notice: true when debug open, will not send message, must enable it to notice under debug open
       # feishu-ntp-target: "pool.ntp.org" # if not set will not sync ntp time
       feishu-webhook:

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -145,6 +145,35 @@ steps:
         - success
 ```
 
+### force notice failure
+
+```yaml
+labels: # https://woodpecker-ci.org/docs/usage/workflow-syntax#labels
+  platform: linux/amd64
+  backend: docker
+
+steps:
+  notification-feishu-failure:
+    image: sinlov/woodpecker-feishu-group-robot:latest
+    pull: false
+    settings:
+      # debug: true # plugin debug switch
+      # force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
+      force-status: "failure"
+      feishu-webhook:
+        # https://woodpecker-ci.org/docs/usage/secrets
+        from_secret: feishu_group_bot_token
+      feishu-secret:
+        from_secret: feishu_group_secret_bot
+      feishu-msg-i18n-lang: en-US # support: en-US, zh-CN more support see --help (v1.4.+)
+      feishu-msg-title: "CI Notification" # default [CI Notification]
+      # let notification card change more info see https://open.feishu.cn/document/ukTMukTMukTM/uAjNwUjLwYDM14CM2ATN
+      feishu-enable-forward: true
+    when:
+      status: # only support failure/success, both open will send anything
+        - failure
+```
+
 ### steps transfer
 
 - The response needs to enable support for the type corresponding to `settings.feishu-notice-types`

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -36,7 +36,7 @@ woodpecker-feishu-group-robot
 | Name                           | Required | Default value     | Description                                                                                                       |
 |--------------------------------|----------|-------------------|-------------------------------------------------------------------------------------------------------------------|
 | `debug`                        | **no**   | *false*           | open debug log or open by env `PLUGIN_DEBUG`                                                                      |
-| `force-status`                 | **no**   | *""*              | force status (1.8+). If empty will use woodpecker ci pipeline status, only support `[success failure]`            |
+| `force-status`                 | **no**   | *""*              | force status (v1.8+). If empty will use woodpecker ci pipeline status, only support `[success failure]`           |
 | `feishu-enable-debug-notice`   | **no**   | *false*           | when debug open, will not send message, must enable it to notice under debug open                                 |
 | `feishu-webhook`               | **yes**  | *none*            | feishu group robot webhook, end of feishu robot `https://open.feishu.cn/open-apis/bot/v2/hook/{web_hook}`         |
 | `feishu-secret`                | **yes**  | *none*            | feishu robot secret, just `signature verification`, empty will not open.                                          |
@@ -80,7 +80,7 @@ steps:
     pull: false
     settings:
       # debug: true # plugin debug switch
-      ## force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
+      ## force status (v1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
       # force-status: "failure"
       # feishu-enable-debug-notice: true when debug open, will not send message, must enable it to notice under debug open
       # feishu-ntp-target: "pool.ntp.org" # if not set will not sync ntp time
@@ -124,7 +124,7 @@ steps:
     image: woodpecker-feishu-group-robot
     settings:
       # debug: true # plugin debug switch
-      ## force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
+      ## force status (v1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
       # force-status: "failure"
       # feishu-enable-debug-notice: true when debug open, will not send message, must enable it to notice under debug open
       # feishu-ntp-target: "pool.ntp.org" # if not set will not sync ntp time
@@ -158,7 +158,7 @@ steps:
     pull: true
     settings:
       # debug: true # plugin debug switch
-      # force status (1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
+      # force status (v1.8+). If empty will use woodpecker ci pipeline status, only support [success failure]
       force-status: "failure"
       feishu-webhook:
         # https://woodpecker-ci.org/docs/usage/secrets

--- a/feishu_plugin/flag.go
+++ b/feishu_plugin/flag.go
@@ -12,6 +12,9 @@ import (
 )
 
 const (
+	CliPluginForceStatus = "settings.force-status"
+	EnvPluginForceStatus = "PLUGIN_FORCE_STATUS"
+
 	// CliPluginFeishuNoticeTypes
 	// feishu_notice_types
 	CliPluginFeishuNoticeTypes = "settings.feishu-notice-types"
@@ -58,7 +61,13 @@ const (
 // Other modules also have flags
 func GlobalFlag() []cli.Flag {
 	return []cli.Flag{
-		// new flag string template if no use, please replace this
+		&cli.StringFlag{
+			Name:    CliPluginForceStatus,
+			Usage:   fmt.Sprintf("force status (1.8+). If empty will use woodpecker ci pipeline status, only support %v", supportRenderStatus),
+			Value:   "",
+			EnvVars: []string{EnvPluginForceStatus},
+		},
+
 		&cli.StringFlag{
 			Name:    CliPluginNtpTarget,
 			Usage:   "ntp target for sync time like: pool.ntp.org, default not use ntpd to sync",
@@ -160,6 +169,8 @@ func BindCliFlags(c *cli.Context,
 		StepsTransferPath: stepsTransferPath,
 		StepsOutDisable:   stepsOutDisable,
 		RootPath:          rootPath,
+
+		ForceStatus: c.String(CliPluginForceStatus),
 
 		NtpTarget:           c.String(CliPluginNtpTarget),
 		Webhook:             c.String(CliPluginWebhook),

--- a/feishu_plugin/flag.go
+++ b/feishu_plugin/flag.go
@@ -63,7 +63,7 @@ func GlobalFlag() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
 			Name:    CliPluginForceStatus,
-			Usage:   fmt.Sprintf("force status (1.8+). If empty will use woodpecker ci pipeline status, only support %v", supportRenderStatus),
+			Usage:   fmt.Sprintf("force status (v1.8+). If empty will use woodpecker ci pipeline status, only support %v", supportRenderStatus),
 			Value:   "",
 			EnvVars: []string{EnvPluginForceStatus},
 		},

--- a/feishu_plugin/impl.go
+++ b/feishu_plugin/impl.go
@@ -98,6 +98,16 @@ func (p *FeishuPlugin) checkArgs() error {
 		return fmt.Errorf("missing feishu webhook, please set feishu webhook")
 	}
 
+	if p.Settings.ForceStatus != "" { // check force status when not empty
+		if !string_tools.StringInArr(p.Settings.ForceStatus, supportRenderStatus) {
+			return fmt.Errorf("settings [ feishu-force-status ], now is: %s , only support %v", p.Settings.ForceStatus, supportRenderStatus)
+		}
+
+		// change status by force status
+		p.woodpeckerInfo.CurrentInfo.CurrentPipelineInfo.CiPipelineStatus = p.Settings.ForceStatus
+		p.wdShortInfo.Build.Status = p.Settings.ForceStatus
+	}
+
 	// set default MsgType
 	if p.Settings.MsgType == "" {
 		p.Settings.MsgType = MsgTypeInteractive

--- a/feishu_plugin/settings.go
+++ b/feishu_plugin/settings.go
@@ -18,6 +18,8 @@ type (
 		RootPath          string
 		DryRun            bool
 
+		ForceStatus string
+
 		NtpTarget string
 
 		Webhook             string

--- a/feishu_plugin_test/feishu_card_template_test.go
+++ b/feishu_plugin_test/feishu_card_template_test.go
@@ -36,6 +36,13 @@ func doTestRenderFeishuCardByi18n(t *testing.T, lang string) {
 	)
 	sampleFailRenderSettings := mockPluginSettings()
 
+	// sampleRenderWithForceStatus
+	sampleRenderWithForceStatusWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(
+		wd_mock.FastCurrentStatus(wd_info.BuildStatusSuccess),
+	)
+	sampleRenderWithForceStatusSettings := mockPluginSettings()
+	sampleRenderWithForceStatusSettings.ForceStatus = wd_info.BuildStatusFailure
+
 	// sampleRenderWithMessage
 	sampleRenderWithMessageWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(
 		wd_mock.FastCurrentStatus(wd_info.BuildStatusSuccess),
@@ -83,6 +90,11 @@ func doTestRenderFeishuCardByi18n(t *testing.T, lang string) {
 			name:           fmt.Sprintf("sample_fail%s", appendTestcase),
 			woodpeckerInfo: sampleFailRenderWoodpeckerInfo,
 			settings:       sampleFailRenderSettings,
+		},
+		{
+			name:           fmt.Sprintf("sample_with_force_status%s", appendTestcase),
+			woodpeckerInfo: sampleRenderWithForceStatusWoodpeckerInfo,
+			settings:       sampleRenderWithForceStatusSettings,
 		},
 		{
 			name:           fmt.Sprintf("sample_with_message%s", appendTestcase),

--- a/feishu_plugin_test/plugin_test.go
+++ b/feishu_plugin_test/plugin_test.go
@@ -18,6 +18,14 @@ func TestCheckArgsPlugin(t *testing.T) {
 	successArgsSettings := mockPluginSettings()
 	successArgsSettings.Webhook = "some webhook"
 
+	// forceStatusFailure
+	forceStatusFailureWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(
+		wd_mock.FastCurrentStatus(wd_info.BuildStatusSuccess),
+	)
+	forceStatusFailureSettings := mockPluginSettings()
+	forceStatusFailureSettings.Webhook = "some webhook"
+	forceStatusFailureSettings.ForceStatus = wd_info.BuildStatusFailure
+
 	// emptyWebhook
 	emptyWebhookWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(
 		wd_mock.FastCurrentStatus(wd_info.BuildStatusSuccess),
@@ -46,6 +54,12 @@ func TestCheckArgsPlugin(t *testing.T) {
 			name:              "successArgs",
 			woodpeckerInfo:    successArgsWoodpeckerInfo,
 			settings:          successArgsSettings,
+			wantArgFlagNotErr: true,
+		},
+		{
+			name:              "forceStatusFailure",
+			woodpeckerInfo:    forceStatusFailureWoodpeckerInfo,
+			settings:          forceStatusFailureSettings,
 			wantArgFlagNotErr: true,
 		},
 		{

--- a/feishu_plugin_test/testdata/TestRenderFeishuCard/sample_with_force_status.golden
+++ b/feishu_plugin_test/testdata/TestRenderFeishuCard/sample_with_force_status.golden
@@ -1,0 +1,69 @@
+{
+  "timestamp": 0,
+  "sign": "",
+  "msg_type": "interactive",
+  "card": {
+    "config": {
+      "enable_forward": true
+    },
+    "header": {
+      "template": "red",
+      "title": {
+        "tag": "plain_text",
+        "content": "[Failure] woodpecker-kit/guidance-woodpecker-agent ➜ build"
+      }
+    },
+    "elements": [
+      {
+        "tag": "markdown",
+        "content": "**CI Notification**"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "markdown",
+        "content": "📝 Commit by **sinlov** on **main**\nCommitCode: 9c764dd487bce596c5c0402478fabde5f0344983"
+      },
+      {
+        "tag": "markdown",
+        "content": "❌ Build [#10](https://woodpecker.domain.com/repos/2/pipeline/10) failure\nWorkflow Name: build"
+      },
+      {
+        "tag": "markdown",
+        "content": "**Commit:**\ntest: use source to load env vars at before step"
+      },
+      {
+        "tag": "markdown",
+        "content": "[See Git Link](https://gitea.domain.com/sinlov/woodpecker-tools/commit/9c764dd487bce596c5c0402478fabde5f0344983) | [See Build Details](https://woodpecker.domain.com/repos/2/pipeline/10)"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "markdown",
+        "content": "**Build Created At:** 2024-01-19-09-55-41\n**Build Time:** 25s\nMachine: worker\nPlatform: linux/amd64\nEvent: push"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "note",
+        "elements": [
+          {
+            "tag": "plain_text",
+            "content": "From 2.3.0@woodpecker.domain.com. Powered By"
+          },
+          {
+            "tag": "img",
+            "img_key": "img_v2_18a207ce-2428-4b5c-8fc0-f791c05d938g",
+            "alt": {
+              "tag": "plain_text",
+              "content": "sinlov"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/feishu_plugin_test/testdata/TestRenderFeishuCardLangEnUS/sample_with_force_status_en-US.golden
+++ b/feishu_plugin_test/testdata/TestRenderFeishuCardLangEnUS/sample_with_force_status_en-US.golden
@@ -1,0 +1,69 @@
+{
+  "timestamp": 0,
+  "sign": "",
+  "msg_type": "interactive",
+  "card": {
+    "config": {
+      "enable_forward": true
+    },
+    "header": {
+      "template": "red",
+      "title": {
+        "tag": "plain_text",
+        "content": "[Failure] woodpecker-kit/guidance-woodpecker-agent ➜ build"
+      }
+    },
+    "elements": [
+      {
+        "tag": "markdown",
+        "content": "**CI Notification**"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "markdown",
+        "content": "📝 Commit by **sinlov** on **main**\nCommitCode: 9c764dd487bce596c5c0402478fabde5f0344983"
+      },
+      {
+        "tag": "markdown",
+        "content": "❌ Build [#10](https://woodpecker.domain.com/repos/2/pipeline/10) failure\nWorkflow Name: build"
+      },
+      {
+        "tag": "markdown",
+        "content": "**Commit:**\ntest: use source to load env vars at before step"
+      },
+      {
+        "tag": "markdown",
+        "content": "[See Git Link](https://gitea.domain.com/sinlov/woodpecker-tools/commit/9c764dd487bce596c5c0402478fabde5f0344983) | [See Build Details](https://woodpecker.domain.com/repos/2/pipeline/10)"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "markdown",
+        "content": "**Build Created At:** 2024-01-19-09-55-41\n**Build Time:** 25s\nMachine: worker\nPlatform: linux/amd64\nEvent: push"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "note",
+        "elements": [
+          {
+            "tag": "plain_text",
+            "content": "From 2.3.0@woodpecker.domain.com. Powered By"
+          },
+          {
+            "tag": "img",
+            "img_key": "img_v2_18a207ce-2428-4b5c-8fc0-f791c05d938g",
+            "alt": {
+              "tag": "plain_text",
+              "content": "sinlov"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/feishu_plugin_test/testdata/TestRenderFeishuCardLangZhCN/sample_with_force_status_zh-CN.golden
+++ b/feishu_plugin_test/testdata/TestRenderFeishuCardLangZhCN/sample_with_force_status_zh-CN.golden
@@ -1,0 +1,69 @@
+{
+  "timestamp": 0,
+  "sign": "",
+  "msg_type": "interactive",
+  "card": {
+    "config": {
+      "enable_forward": true
+    },
+    "header": {
+      "template": "red",
+      "title": {
+        "tag": "plain_text",
+        "content": "[Failure] woodpecker-kit/guidance-woodpecker-agent ➜ build"
+      }
+    },
+    "elements": [
+      {
+        "tag": "markdown",
+        "content": "**CI Notification**"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "markdown",
+        "content": "📝 提交人 **sinlov** 分支 **main**\n提交Code: 9c764dd487bce596c5c0402478fabde5f0344983"
+      },
+      {
+        "tag": "markdown",
+        "content": "❌ 构建编号 [#10](https://woodpecker.domain.com/repos/2/pipeline/10) failure\n工作流名称: build"
+      },
+      {
+        "tag": "markdown",
+        "content": "**提交信息:**\ntest: use source to load env vars at before step"
+      },
+      {
+        "tag": "markdown",
+        "content": "[查看 Git 链接](https://gitea.domain.com/sinlov/woodpecker-tools/commit/9c764dd487bce596c5c0402478fabde5f0344983) | [查看构建详情](https://woodpecker.domain.com/repos/2/pipeline/10)"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "markdown",
+        "content": "**构建开始于: ** 2024-01-19-09-55-41\n**构建时间: ** 25s\n构建设备: worker\n平台标识: linux/amd64\n触发事件: push"
+      },
+      {
+        "tag": "hr"
+      },
+      {
+        "tag": "note",
+        "elements": [
+          {
+            "tag": "plain_text",
+            "content": "From 2.3.0@woodpecker.domain.com. Powered By"
+          },
+          {
+            "tag": "img",
+            "img_key": "img_v2_18a207ce-2428-4b5c-8fc0-f791c05d938g",
+            "alt": {
+              "tag": "plain_text",
+              "content": "sinlov"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
feat #36

- Introduce new `force-status` setting to override the default pipeline status
- Update documentation and add new test cases for the force status feature
- Modify the Feishu plugin implementation to handle the force status option
